### PR TITLE
allow to fetch particular environment

### DIFF
--- a/lib/figaro.rb
+++ b/lib/figaro.rb
@@ -3,8 +3,8 @@ require "figaro/railtie"
 module Figaro
   extend self
 
-  def env
-    flatten(raw).merge(raw.fetch(environment, {}))
+  def env(_environment_ = nil)
+    flatten(raw).merge(raw.fetch(_environment_ || environment, {}))
   end
 
   def raw


### PR DESCRIPTION
With this commit we now able to:

```
Figaro.env # fetch default env
Figaro.env('production') # fetch production env
Figaro.env('production').to_yaml # construct yaml configuration for production box
```

This is important because usually we deploy our configuration to staging/production server. Allowing Figaro to fetch particular environment will be huge benefits to securely export configuration based on environment. Say you have `capistrano` task:

```
namespace :deploy do
  task :config do
    run_locally %Q(rails runner 'puts Figaro.env("#{stage}").to_yaml' > _application_.yml)
    transfer :up, '_application_.yml', "#{shared_path}/application.yml", via: :scp
    run_locally 'rm _application_.yml'
  end
end
```

Now we have specific `application.yml` on each server without contains any other environment configuration.

EDIT: Sorry, there is no test for it. I don't familiar with cucumber test :(
