### PR TITLE
Set proper environment from Heroku

### DIFF
--- a/lib/figaro.rb
+++ b/lib/figaro.rb
@@ -20,7 +20,11 @@ module Figaro
   end
 
   def environment
-    Rails.env
+    @environment || Rails.env
+  end
+
+  def environment=(other_env)
+    @environment = other_env
   end
 
   private

--- a/lib/figaro/tasks.rake
+++ b/lib/figaro/tasks.rake
@@ -1,6 +1,8 @@
 namespace :figaro do
   desc "Configure Heroku according to application.yml"
   task :heroku, [:app] => :environment do |_, args|
+    heroku_env = `heroku config:get RAILS_ENV`.chomp
+    Figaro.environment = heroku_env
     vars = Figaro.env.map{|k,v| "#{k}=#{v}" }.sort.join(" ")
     command = "heroku config:add #{vars}"
     command << " --app #{args[:app]}" if args[:app]


### PR DESCRIPTION
For one of my projects I use Heroku for staging and I noticed when setting up figaro that it was using the environment set on my local machine for environment specific configs being set on Heroku. This commit checks what the RAILS_ENV is set to on Heroku and has figaro use that environment.
