### PR TITLE
Does not work with nil values.

### DIFF
--- a/features/rails.feature
+++ b/features/rails.feature
@@ -10,11 +10,7 @@ Feature: Rails
       end
 
       task :nena => :environment do
-        if ENV["LUFTBALLOONS"]
-          puts [ENV["LUFTBALLOONS"], "Luftballoons"].compact.join(" ")
-        else
-          puts "There aren't any ballons today."
-        end
+        puts [ENV["LUFTBALLOONS"], "Luftballoons"].compact.join(" ")
       end
 
       task :greet => :environment do
@@ -90,14 +86,6 @@ Feature: Rails
       """
     When I run "rake nena"
     Then the output should be "99 Luftballoons"
-
-  Scenario: Has application.yml with nil values
-    Given I create "config/application.yml" with:
-      """
-      LUFTBALLOONS: ~
-      """
-    When I run "rake nena"
-    Then the output should be "There aren't any ballons today."
 
   Scenario: Generator creates and ignores application.yml file
     When I run "rails generate figaro:install"

--- a/spec/figaro_spec.rb
+++ b/spec/figaro_spec.rb
@@ -47,5 +47,12 @@ describe Figaro do
 
       Figaro.env.should == { "LUFTBALLOONS" => "99" }
     end
+
+    it "leaves nil values undefined" do
+      Figaro.stub(:raw).and_return(:LUFTBALLOONS => "ballons", :NIL_VALUE => nil)
+
+      Figaro.env.should == { "LUFTBALLOONS" => "ballons" }
+    end
+
   end
 end


### PR DESCRIPTION
I have different environments, and I need to define and environmental variable on one of those and not in others, nor of this seems to work for me:

```
DEBUGGING: ~
development:
  DEBUGGING: true

Figaro.env.debugging #=> ""
```

```
development:
  DEBUGGING: true

Figaro.env.debugging #=> "true"
```

I may be missing something.
