### PR TITLE
Avoid Ruby version error in Bundler

### DIFF
--- a/lib/figaro/tasks.rb
+++ b/lib/figaro/tasks.rb
@@ -3,10 +3,10 @@ module Figaro
     def self.heroku(app = nil)
       with_app = app ? " --app #{app}" : ""
 
-      rails_env = `heroku config:get RAILS_ENV#{with_app}`.chomp
+      rails_env = Bundler.with_clean_env{`heroku config:get RAILS_ENV#{with_app}`}.chomp
       vars = Figaro.vars(rails_env.presence)
 
-      `heroku config:add #{vars}#{with_app}`
+      Bundler.with_clean_env{`heroku config:add #{vars}#{with_app}`}
     end
   end
 end


### PR DESCRIPTION
Fixes issue #34. By changing these lines in a local Figaro gem installation, I was able to test these changes.

In the test, bundle exec rake figaro:heroku no longer crashes the Rake task. It succeeds in setting a Heroku configuration environment variable.
