### PR TITLE
Use the true Heroku Rails environment

### DIFF
--- a/lib/figaro/tasks.rb
+++ b/lib/figaro/tasks.rb
@@ -1,12 +1,18 @@
 module Figaro
   module Tasks
+    RESPONSE_HEADER_LINE_COUNT = 1
+
     def self.heroku(app = nil)
       with_app = app ? " --app #{app}" : ""
 
-      rails_env = `heroku config:get RAILS_ENV#{with_app}`.chomp
+      shell_command = 'heroku run "echo \$RAILS_ENV"'
+      response = Bundler.with_clean_env{`#{shell_command}`}
+      rails_env = response.lines.drop(RESPONSE_HEADER_LINE_COUNT).join('').strip
+# STDOUT.print "rails_env is #{rails_env}\n"
+
       vars = Figaro.vars(rails_env.presence)
 
-      `heroku config:add #{vars}#{with_app}`
+      Bundler.with_clean_env{`heroku config:add #{vars}#{with_app}`}
     end
   end
 end

--- a/spec/figaro/tasks_spec.rb
+++ b/spec/figaro/tasks_spec.rb
@@ -5,8 +5,8 @@ describe Figaro::Tasks do
     it "configures Heroku" do
       Figaro.stub(:vars => "FOO=bar")
 
-      Figaro::Tasks.should_receive(:`).once.with("heroku config:get RAILS_ENV").
-        and_return("development\n")
+      Figaro::Tasks.should_receive(:`).once.with('heroku run "echo \$RAILS_ENV"').
+        and_return("\ndevelopment\n")
       Figaro::Tasks.should_receive(:`).once.with("heroku config:add FOO=bar")
 
       Figaro::Tasks.heroku
@@ -16,8 +16,8 @@ describe Figaro::Tasks do
       Figaro.stub(:vars => "FOO=bar")
 
       Figaro::Tasks.should_receive(:`).once.
-        with("heroku config:get RAILS_ENV --app my-app").
-        and_return("development\n")
+        with('heroku run "echo \$RAILS_ENV"').
+        and_return("\ndevelopment\n")
       Figaro::Tasks.should_receive(:`).once.
         with("heroku config:add FOO=bar --app my-app")
 
@@ -25,8 +25,8 @@ describe Figaro::Tasks do
     end
 
     it "respects the Heroku's remote Rails environment" do
-      Figaro::Tasks.stub(:`).with("heroku config:get RAILS_ENV").
-        and_return("production\n")
+      Figaro::Tasks.stub(:`).with('heroku run "echo \$RAILS_ENV"').
+        and_return("\nproduction\n")
 
       Figaro.should_receive(:vars).once.with("production").and_return("FOO=bar")
       Figaro::Tasks.should_receive(:`).once.with("heroku config:add FOO=bar")
@@ -35,8 +35,8 @@ describe Figaro::Tasks do
     end
 
     it "defaults to the local Rails environment if not set remotely" do
-      Figaro::Tasks.stub(:`).with("heroku config:get RAILS_ENV").
-        and_return("\n")
+      Figaro::Tasks.stub(:`).with('heroku run "echo \$RAILS_ENV"').
+        and_return("\n\n")
 
       Figaro.should_receive(:vars).once.with(nil).and_return("FOO=bar")
       Figaro::Tasks.should_receive(:`).once.with("heroku config:add FOO=bar")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "figaro"
 require "pathname"
+require "bundler"
 
 ROOT = Pathname.new(File.expand_path("../..", __FILE__))
 


### PR DESCRIPTION
Fixes issues #35 and #34 (Bundler Ruby version error). All tests pass.

In the case that a user sets RAILS_ENV in Heroku config, that works okay, too. So, we remain compatible with this past user practice.

And Heroku respects it, and sets its internal value for the Rails environment. And this is what is accessed, now.
