### PR TITLE
Replaced respond_to? with respond_to_missing?

### DIFF
--- a/lib/figaro/env.rb
+++ b/lib/figaro/env.rb
@@ -8,8 +8,8 @@ module Figaro
       ENV.fetch(method.to_s.upcase) { super }
     end
 
-    def respond_to?(method)
-      ENV.key?(method.to_s.upcase)
+    def respond_to_missing?(*args)
+      ENV.key?(args.first.to_s.upcase)
     end
   end
 end


### PR DESCRIPTION
Better practice to redefine respond_to_missing?. You get all the benefits of redefining respond_to? with the added benefit that callings "method(name)" returns true for the methods you've redefined
