### PR TITLE
add simple check for yaml parse error

### DIFF
--- a/lib/figaro.rb
+++ b/lib/figaro.rb
@@ -6,6 +6,9 @@ require "figaro/tasks"
 module Figaro
   extend self
 
+  class YAMLParseError < StandardError
+  end
+
   def vars(custom_environment = nil)
     env(custom_environment).map { |key, value|
       "#{key}=#{Shellwords.escape(value)}"
@@ -36,7 +39,11 @@ module Figaro
   private
 
   def flatten(hash)
-    hash.reject { |_, v| Hash === v }
+    if hash.is_a?(Hash)
+      hash.reject { |_, v| Hash === v }
+    else
+      raise YAMLParseError, "Please check the syntax of config/application.yml"
+    end
   end
 
   def stringify(hash)

--- a/spec/figaro_spec.rb
+++ b/spec/figaro_spec.rb
@@ -59,5 +59,11 @@ describe Figaro do
 
       expect(Figaro.env).to eq("FOO" => "true", "BAR" => "false")
     end
+
+    it "throws an exception for invalid syntax" do
+      Figaro.stub(:raw => "Foo: true\n Bar: false\n")
+
+      expect { flatten(raw) }.to raise_error
+    end
   end
 end


### PR DESCRIPTION
When using figaro, a simple syntax error in my config/application.yml file caused bugs in the flatten method and it took a while to figure out why (YAML converts improper files to strings apparently). Throwing an exception here would be nice to alert the user that something's wrong with their yml file. 
