### PR TITLE
Add required_keys!(...) method to Env

### DIFF
--- a/lib/figaro/env.rb
+++ b/lib/figaro/env.rb
@@ -2,6 +2,14 @@ module Figaro
   module ENV
     extend self
 
+    def required_keys!(*keys)
+      missing_keys = keys.map { |key| key.upcase if send(key).to_s == '' }.compact
+
+      unless missing_keys.size.zero?
+        raise Figaro::MissingKey.new("Missing required Figaro configuration keys #{missing_keys.join(', ')}.")
+      end
+    end
+
     def respond_to?(method, *)
       key, punctuation = extract_key_from_method(method)
 

--- a/spec/figaro/env_spec.rb
+++ b/spec/figaro/env_spec.rb
@@ -13,6 +13,28 @@ describe Figaro::ENV do
     ENV.delete("foo")
   end
 
+  describe '#required_keys!' do
+    context 'when all keys are present' do
+      it 'raises no exceptions' do
+        expect{env.required_keys!(:hello, :foo)}.to_not raise_error(Figaro::MissingKey)
+      end
+
+      it 'handles plain strings' do
+        expect{env.required_keys!('hello', 'foo')}.to_not raise_error(Figaro::MissingKey)
+      end
+    end
+
+    context 'when missing keys' do
+      it 'raises MissingKey exception' do
+        expect{env.required_keys!(:hello, :baz)}.to raise_error(Figaro::MissingKey)
+      end
+
+      it 'emits all missing keys in error message' do
+        expect{env.required_keys!(:hello, :baz, :qux)}.to raise_error(Figaro::MissingKey, /BAZ, QUX/)
+      end
+    end
+  end
+
   describe "#method_missing" do
     context "plain methods" do
       it "makes ENV values accessible as lowercase methods" do


### PR DESCRIPTION
Allows you to do an aggressive post launch test to confirm all the
keys your apps need are present and ready to go.

It will raise an exception if any are missing and it will tell you
which of the required keys are missing.

Use this in rake tasks so cap can bail mid deploy, or in production.rb
to stop server boots.
