### PR TITLE
Add comparison tasks to Figaro

### DIFF
--- a/lib/figaro/rails/tasks.rake
+++ b/lib/figaro/rails/tasks.rake
@@ -3,4 +3,16 @@ namespace :figaro do
   task :heroku, [:app] => :environment do |_, args|
     Figaro::Tasks::Heroku.new(args[:app]).invoke
   end
+
+  namespace :heroku do
+    desc "Show the changes that will be made to Heroku according to application.yml"
+    task :show, [:app] => :environment do |_, args|
+      Figaro::Tasks::Heroku.new(args[:app]).show
+    end
+
+    desc "Compare Heroku config to that from application.yml"
+    task :diff, [:app] => :environment do |_, args|
+      Figaro::Tasks::Heroku.new(args[:app]).diff
+    end
+  end
 end

--- a/lib/figaro/tasks.rb
+++ b/lib/figaro/tasks.rb
@@ -23,6 +23,38 @@ module Figaro
       def `(command)
         Bundler.with_clean_env { super }
       end
+
+      def show(io = $stdout)
+        data = Figaro.env(environment)
+        maxl = data.keys.map(&:size).max
+
+        io.puts "=== PROPOSED #{app || 'default'} Config Vars"
+        data.keys.sort.each { |k|
+          pk = "#{k}:"
+          io.puts "#{pk.ljust(maxl + 1)} #{data[k]}"
+        }
+      end
+
+      def diff
+        app_name = app || 'default'
+
+        current_config  = Rails.root.join('tmp', "#{app}.config")
+        proposed_config = Rails.root.join('tmp', "#{app}.proposed")
+
+        File.open(current_config, 'w') { |f|
+          f.puts heroku("config")
+        }
+
+        File.open(proposed_config, 'w') { |f|
+          show(f)
+        }
+
+        system 'git', 'diff', '--no-index', current_config.to_path,
+          proposed_config.to_path
+      ensure
+        current_config.unlink if current_config.exist?
+        proposed_config.unlink if proposed_config.exist?
+      end
     end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -61,7 +61,9 @@ EOF
     it "is included" do
       run_simple("bundle exec rake --tasks figaro:heroku")
 
-      assert_partial_output("rake figaro:heroku[app]  # Configure Heroku according to application.yml", all_stdout)
+      assert_partial_output("rake figaro:heroku[app]       # Configure Heroku according to application.yml", all_stdout)
+      assert_partial_output("rake figaro:heroku:diff[app]  # Compare Heroku config to that from application.yml", all_stdout)
+      assert_partial_output("rake figaro:heroku:show[app]  # Show the changes that will be made to Heroku according to application.yml", all_stdout)
     end
   end
 end


### PR DESCRIPTION
- Adds figaro:heroku:show[app] to display the PROPOSED config changes
  (in the same format as `heroku config --app APP` displays).
- Adds figaro:heroku:diff[app] to automatically display the config
  changes.
