### PR TITLE
Make Figaro load configuration earlier so it can be used in database.yml

### DIFF
--- a/lib/figaro/rails/railtie.rb
+++ b/lib/figaro/rails/railtie.rb
@@ -1,7 +1,7 @@
 module Figaro
   module Rails
     class Railtie < ::Rails::Railtie
-      initializer "figaro.load", before: :load_environment_config do
+      config.before_configuration do
         Figaro.load
       end
     end


### PR DESCRIPTION
This pull requests initializes Figaro earlier so it can be used in places like database.yml. I'm not sure if this will cause any other problems, but tests completely passed after this change.
