### PR TITLE
Fixes image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ No problem. Just add `config/application.yml` to your production app on the serv
 
 Yes.
 
-[![Figaro](http://images2.wikia.nocookie.net/__cb20100628192722/disney/images/5/53/Pinocchio-pinocchio-4947890-960-720.jpg "Figaro's mascot: Figaro")](http://en.wikipedia.org/wiki/Figaro_(Disney\))
+[![Figaro](http://images2.wikia.nocookie.net/__cb20100628192722/disney/images/5/53/Pinocchio-pinocchio-4947890-960-720.jpg "Figaro's mascot: Figaro")](http://en.wikipedia.org/wiki/Figaro_(Disney))
 
 ## Thank you!
 


### PR DESCRIPTION
Unnecessary escape of `/` which broke the layout.
