### PR TITLE
Tie into Rails initialization as early as possible

### DIFF
--- a/lib/figaro/rails/railtie.rb
+++ b/lib/figaro/rails/railtie.rb
@@ -1,7 +1,7 @@
 module Figaro
   module Rails
     class Railtie < ::Rails::Railtie
-      initializer "figaro.load", before: :load_environment_config do
+      config.before_configuration do
         Figaro.load
       end
     end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -35,6 +35,17 @@ EOF
 
       check_file_presence(["db/bar.sqlite3"], true)
     end
+
+    it "happens before application configuration" do
+      insert_into_file_after("config/application.rb", /< Rails::Application$/, <<-EOL)
+    config.foo = ENV["FOO"]
+EOL
+
+      write_file("config/application.yml", "FOO: bar")
+      run_simple("rails runner 'puts Rails.application.config.foo'")
+
+      assert_partial_output("bar", all_stdout)
+    end
   end
 
   describe "rails generate figaro:install" do

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -1,7 +1,16 @@
 require "aruba/api"
 
+module ArubaHelpers
+  def insert_into_file_after(file, pattern, addition)
+    content = prep_for_fs_check { IO.read(file) }
+    content.sub!(pattern, "\\0\n#{addition}")
+    overwrite_file(file, content)
+  end
+end
+
 RSpec.configure do |config|
   config.include(Aruba::Api)
+  config.include(ArubaHelpers)
 
   config.before do
     @aruba_timeout_seconds = 60


### PR DESCRIPTION
This enables use of Figaro-set `ENV` variables from the config block in `config/application.rb`.
