### PR TITLE
Allow documenting required keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Figaro.require("pusher_app_id", "pusher_key", "pusher_secret")
 
 If any of the configuration keys above are not set, your application will raise an error during initialization. This method is preferred because it prevents runtime errors in a production application due to improper configuration.
 
+You can also document the different configuration keys by specifying them with a hash:
+
+```ruby
+# config/initializers/figaro.rb
+
+Figaro.require({
+  google_analytics_key: 'Get it at https://www.google.com/analytics/web/ (e.g: UA-12345678-1)',
+  # ...
+})
+```
+
 To require configuration keys lazily, reference the variables via "bang" methods on `Figaro.env`:
 
 ```ruby

--- a/lib/figaro.rb
+++ b/lib/figaro.rb
@@ -23,9 +23,14 @@ module Figaro
     application.load
   end
 
-  def require(*keys)
-    missing_keys = keys.flatten - ::ENV.keys
-    raise MissingKeys.new(missing_keys) if missing_keys.any?
+  def require(*required)
+    if required.first.respond_to?(:keys)
+      missing = required.first.reject{ |k,v| ::ENV.keys.include?(k.to_s) }
+    else
+      missing = required.flatten - ::ENV.keys
+    end
+
+    raise MissingKeys.new(missing) if missing.any?
   end
 end
 

--- a/lib/figaro/error.rb
+++ b/lib/figaro/error.rb
@@ -5,8 +5,13 @@ module Figaro
   class MissingKey < Error; end
 
   class MissingKeys < Error
-    def initialize(keys)
-      super("Missing required configuration keys: #{keys.inspect}")
+    def initialize(missing)
+      if missing.respond_to?(:keys)
+        list = missing.map{ |k,v| "- #{k}: #{v}" }.join("\n").prepend("\n")
+      else
+        list = missing.inspect
+      end
+      super("Missing required configuration keys: #{list}")
     end
   end
 end

--- a/spec/figaro_spec.rb
+++ b/spec/figaro_spec.rb
@@ -66,35 +66,47 @@ describe Figaro do
       ::ENV["hello"] = "world"
     end
 
-    context "when no keys are missing" do
-      it "does nothing" do
-        expect {
-          Figaro.require("foo", "hello")
-        }.not_to raise_error
+    context "called with an array" do
+      context "when no keys are missing" do
+        it "does nothing" do
+          expect {
+            Figaro.require("foo", "hello")
+          }.not_to raise_error
+        end
       end
 
-      it "accepts an array" do
-        expect {
-          Figaro.require(["foo", "hello"])
-        }.not_to raise_error
+      context "when keys are missing" do
+        it "raises an error for the missing keys" do
+          expect {
+            Figaro.require("foo", "goodbye", "baz")
+          }.to raise_error(Figaro::MissingKeys) { |error|
+            expect(error.message).not_to include("foo")
+            expect(error.message).to include("goodbye")
+            expect(error.message).to include("baz")
+          }
+        end
       end
     end
 
-    context "when keys are missing" do
-      it "raises an error for the missing keys" do
-        expect {
-          Figaro.require("foo", "goodbye", "baz")
-        }.to raise_error(Figaro::MissingKeys) { |error|
-          expect(error.message).not_to include("foo")
-          expect(error.message).to include("goodbye")
-          expect(error.message).to include("baz")
-        }
+    context "called with a hash" do
+      context "when no keys are missing" do
+        it "does nothing" do
+          expect {
+            Figaro.require(foo: 'foo explained', hello: 'hello explained')
+          }.not_to raise_error
+        end
       end
 
-      it "accepts an array" do
-        expect {
-          Figaro.require(["foo", "goodbye", "baz"])
-        }.to raise_error(Figaro::MissingKeys)
+      context "when keys are missing" do
+        it "raises an error for the missing keys including explanations" do
+          expect {
+            Figaro.require(foo: 'foo explained', goodbye: 'goodbye explained', baz: 'baz explained')
+          }.to raise_error(Figaro::MissingKeys) { |error|
+            expect(error.message).not_to include("foo")
+            expect(error.message).to include("- goodbye: goodbye explained")
+            expect(error.message).to include("- baz: baz explained")
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
I typically document the purpose of each config variable and how to get it. I'd love Figaro to help me with that and this is a first step in that direction (only dealing with required variables right now):

``` ruby
# config/initializers/figaro.rb

Figaro.require({
  google_analytics_key: 'Get it at https://www.google.com/analytics/web/ (e.g: UA-12345678-1)',
  # ...
})
```

``` bash
# Execute the app without ENV['GOOGLE_ANALYTICS_KEY']
$ bundle exec rails s

Missing required configuration keys:  (Figaro::MissingKeys)
- google_analytics_key: Get it at https://www.google.com/analytics/web/ (e.g: UA-12345678-1)
```

The existing array-based interface is still available.

I'd love to expand Figaro to do something like:

``` bash
$ figaro
== Required
[x] AAA: Credentials to access the Aaa service, get them at http://aaa.com/credentials
[x] ZZZ: Credentials to access the Zzz service, get them at http://zzz.com/account
[ ] BBB: Credentials to access the Bbb add-on, get them with `heroku addons:add bbb`

== Optional
[x] YYY: Credentials to access the Yyy service, get them at http://yyy.com/account
[ ] CCC: Credentials to access the Ccc service, get them at http://ccc.com/credentials
```

and

``` bash
$ figaro missing
BBB:  Credentials to access the Bbb service, get them at http://bbb.com/profile
```

How do you like this approach?
