### PR TITLE
Spring watches application.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ group :test do
   gem "aruba", "~> 0.5"
   gem "codeclimate-test-reporter", "~> 0.3.0", require: false
   gem "rspec", "~> 2.14"
-  gem 'pry'
-
   gem 'debugger'
   gem "sqlite3", "~> 1.3"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,8 @@ group :test do
   gem "aruba", "~> 0.5"
   gem "codeclimate-test-reporter", "~> 0.3.0", require: false
   gem "rspec", "~> 2.14"
+  gem 'pry'
+
+  gem 'debugger'
   gem "sqlite3", "~> 1.3"
 end

--- a/lib/figaro/cli.rb
+++ b/lib/figaro/cli.rb
@@ -1,6 +1,7 @@
 require "thor"
 
 require "figaro/cli/heroku_set"
+require "figaro/cli/installer"
 
 module Figaro
   class CLI < Thor
@@ -19,6 +20,17 @@ module Figaro
 
     define_method "heroku:set" do
       HerokuSet.run(options)
+    end
+
+
+    desc "install", "Installs Figaro into your app"
+
+    method_option "spring",
+      aliases: ["--spring"],
+      desc: "Configurs Figaro files for Spring.  Creates a config/spring.rb file if there isn't one present."
+    
+    define_method "install" do 
+      Installer.run(options)
     end
   end
 end

--- a/lib/figaro/cli/installer.rb
+++ b/lib/figaro/cli/installer.rb
@@ -1,0 +1,18 @@
+require "figaro/cli/task"
+
+module Figaro
+  class CLI < Thor
+    class Installer < Task
+      def run
+        system(command)
+      end
+
+      private
+      
+      def command
+        "rails generate figaro:install #{Thor::Options.to_switches(options)}"
+      end
+
+    end
+  end
+end

--- a/lib/generators/figaro/install/install_generator.rb
+++ b/lib/generators/figaro/install/install_generator.rb
@@ -18,6 +18,20 @@ module Figaro
           end
         end
       end
+      
+      def spring_configuration
+        if File.exists?(".spring.rb")
+          spring_file = "spring.rb"
+        elsif File.exists?("config/spring.rb")
+          spring_file = "config/spring.rb"          
+        else
+          spring_file = "config/spring.rb"          
+          create_file(spring_file)
+        end
+        
+        append_to_file spring_file, 'Spring.watch "config/application.yml"' 
+      end
+      
     end
   end
 end

--- a/lib/generators/figaro/install/install_generator.rb
+++ b/lib/generators/figaro/install/install_generator.rb
@@ -20,9 +20,17 @@ module Figaro
       end
       
       def spring_configuration
-        create_file("config/spring.rb") unless File.exists?("config/spring.rb")
-        append_to_file "config/spring.rb", 'Spring.watch "config/application.yml"' 
-        system('touch config/application.rb') # causes spring to load the changes we introduced above.
+        if File.exists?('Gemfile')
+          spring_included = false #not extracted because we're in an installer
+          File.open("Gemfile", 'r+') do |file|
+            file.each_line{|line| spring_included = true if /gem ['"]spring['"]/.match line}
+          end
+          if spring_included
+            create_file("config/spring.rb") unless File.exists?("config/spring.rb")
+            append_to_file "config/spring.rb", 'Spring.watch "config/application.yml"' 
+            system('touch config/application.rb') # causes spring to load the changes we introduced above.
+          end
+        end
       end
       
     end

--- a/lib/generators/figaro/install/install_generator.rb
+++ b/lib/generators/figaro/install/install_generator.rb
@@ -2,7 +2,8 @@ module Figaro
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
-
+      class_option :spring, type: :boolean, default: false
+      
       def create_configuration
         copy_file("application.yml", "config/application.yml")
       end
@@ -20,16 +21,11 @@ module Figaro
       end
       
       def spring_configuration
-        if File.exists?('Gemfile')
-          spring_included = false #not extracted because we're in an installer
-          File.open("Gemfile", 'r+') do |file|
-            file.each_line{|line| spring_included = true if /gem ['"]spring['"]/.match line}
-          end
-          if spring_included
-            create_file("config/spring.rb") unless File.exists?("config/spring.rb")
-            append_to_file "config/spring.rb", 'Spring.watch "config/application.yml"' 
-            system('touch config/application.rb') # causes spring to load the changes we introduced above.
-          end
+        spring_config = File.exists?("config/spring.rb")
+        if options.spring? || spring_config
+          create_file("config/spring.rb") unless spring_config
+          append_to_file "config/spring.rb", 'Spring.watch "config/application.yml"' 
+          system('touch config/application.rb') # causes spring to load the changes we introduced above.
         end
       end
       

--- a/lib/generators/figaro/install/install_generator.rb
+++ b/lib/generators/figaro/install/install_generator.rb
@@ -20,16 +20,8 @@ module Figaro
       end
       
       def spring_configuration
-        if File.exists?(".spring.rb")
-          spring_file = "spring.rb"
-        elsif File.exists?("config/spring.rb")
-          spring_file = "config/spring.rb"          
-        else
-          spring_file = "config/spring.rb"          
-          create_file(spring_file)
-        end
-        
-        append_to_file spring_file, 'Spring.watch "config/application.yml"' 
+        create_file("config/spring.rb") unless File.exists?("config/spring.rb")
+        append_to_file "config/spring.rb", 'Spring.watch "config/application.yml"' 
       end
       
     end

--- a/lib/generators/figaro/install/install_generator.rb
+++ b/lib/generators/figaro/install/install_generator.rb
@@ -22,6 +22,7 @@ module Figaro
       def spring_configuration
         create_file("config/spring.rb") unless File.exists?("config/spring.rb")
         append_to_file "config/spring.rb", 'Spring.watch "config/application.yml"' 
+        system('touch config/application.rb') # causes spring to load the changes we introduced above.
       end
       
     end

--- a/spec/figaro/cli/install_spec.rb
+++ b/spec/figaro/cli/install_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "figaro/cli"
+
+describe "figaro install" do
+  before do
+    run_simple(<<-CMD)
+      rails new example \
+        --skip-bundle \
+        --skip-keeps \
+        --skip-sprockets \
+        --skip-javascript \
+        --skip-test-unit \
+        --no-rc \
+        --quiet
+      CMD
+    cd("example")
+  end
+
+  it "inserts application.yml" do
+    run_simple("figaro install")
+    check_file_presence(["config/application.yml"], true)
+  end
+  
+  it "ignores application.yml" do
+    run_simple("figaro install")
+    check_file_content(".gitignore", %r(^/config/application\.yml$), true)
+  end
+  
+  it "inserts application.yml into spring config files" do
+    run_simple("figaro install --spring")
+    check_file_content("config/spring.rb", %r((Spring\.watch).*(\"config\/application\.yml\")), true)
+  end
+end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -62,5 +62,11 @@ EOL
 
       check_file_content(".gitignore", %r(^/config/application\.yml$), true)
     end
+    
+    it "inserts application.yml into spring config files" do
+      run_simple("rails generate figaro:install")
+      check_file_content("config/spring.rb", %r((Spring\.watch).*(\"config\/application\.yml\")), true)
+    end
+    
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -51,7 +51,7 @@ EOL
 
   describe "rails generate figaro:install" do
     it "generates application.yml" do
-      run_simple("rails generate figaro:install")
+      run_simple("rails generate figaro:install")   
       check_file_presence(["config/application.yml"], true)
     end
 
@@ -61,14 +61,8 @@ EOL
     end
     
     it "inserts application.yml into spring config files" do
-      run_simple("rails generate figaro:install")
+      run_simple("rails generate figaro:install --spring")
       check_file_content("config/spring.rb", %r((Spring\.watch).*(\"config\/application\.yml\")), true)
-    end
-    
-    it "doesn't touch spring config files if gem isn't present" do
-      overwrite_file('Gemfile', '')
-      run_simple("rails generate figaro:install")
-      check_file_presence(["config/spring.rb"], false)
     end
     
   end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -4,7 +4,6 @@ describe Figaro::Rails do
   before do
     run_simple(<<-CMD)
       rails new example \
-        --skip-gemfile \
         --skip-bundle \
         --skip-keeps \
         --skip-sprockets \
@@ -53,19 +52,23 @@ EOL
   describe "rails generate figaro:install" do
     it "generates application.yml" do
       run_simple("rails generate figaro:install")
-
       check_file_presence(["config/application.yml"], true)
     end
 
     it "ignores application.yml" do
       run_simple("rails generate figaro:install")
-
       check_file_content(".gitignore", %r(^/config/application\.yml$), true)
     end
     
     it "inserts application.yml into spring config files" do
       run_simple("rails generate figaro:install")
       check_file_content("config/spring.rb", %r((Spring\.watch).*(\"config\/application\.yml\")), true)
+    end
+    
+    it "doesn't touch spring config files if gem isn't present" do
+      overwrite_file('Gemfile', '')
+      run_simple("rails generate figaro:install")
+      check_file_presence(["config/spring.rb"], false)
     end
     
   end


### PR DESCRIPTION
Test covers that 'Spring.watch config/application.yml' is appended to config/spring.rb - which according to the spring gem documentation, is what is required to have Spring watch a file.  

I struggled with writing a test that would test whether Spring actually loads that file into it's watched file list.   Loading up Spring within the context of the Aruba sub-rails application in a test proved difficult.  

![Inception](http://media0.giphy.com/media/yAOjunY81Trjy/giphy.gif)

It could be argued that such a test isn't necessary - Spring is now a part of Rails, and should be expected to perform as described - a test should cover that we interface with their system correctly, not test their system.  

Regardless, if such a test is implemented, it should test whether Spring.watcher.files includes config/application.yml

I spun up a new rails app, and pointed the figaro gem to my fork - Spring successfully watched config/application.yml upon figaro installation without any further user input. Pictures of such are below. 

![image](https://cloud.githubusercontent.com/assets/3952646/2781991/446d06c8-cb1a-11e3-81eb-664833c1b414.png)

![image](https://cloud.githubusercontent.com/assets/3952646/2782016/bcf8a214-cb1a-11e3-9077-63ea9641ef06.png)
