### PR TITLE
Rename Figaro.require to required_keys

### DIFF
--- a/lib/figaro.rb
+++ b/lib/figaro.rb
@@ -23,7 +23,7 @@ module Figaro
     application.load
   end
 
-  def require(*keys)
+  def required_keys(*keys)
     missing_keys = keys.flatten - ::ENV.keys
     raise MissingKeys.new(missing_keys) if missing_keys.any?
   end


### PR DESCRIPTION
It's not a good idea to use a ruby reserved word for required keys. Renamed to something slightly more verbose.
