### PR TITLE
fixed install instructions for rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Figaro installation is easy:
 
 
 ```bash
-$ figaro install
+$ rails generate figaro install
 ```
 
 This creates a commented `config/application.yml` file and adds it to your `.gitignore`. Add your own configuration to this file and you're done!


### PR DESCRIPTION
The readme has the wrong instructions for how to install figaro in Rails. This commit fixes that one line in the readme, per [#159](https://github.com/laserlemon/figaro/issues/159#issuecomment-55544276). 
