### PR TITLE
Adds a way to always override existing environment variables with application.yml

### DIFF
--- a/lib/figaro/application.rb
+++ b/lib/figaro/application.rb
@@ -77,7 +77,7 @@ module Figaro
     end
 
     def skip?(key)
-      ::ENV.key?(key.to_s) && !::ENV.key?(FIGARO_ENV_PREFIX + key.to_s)
+      ::ENV.key?(key.to_s) && !::ENV.key?(FIGARO_ENV_PREFIX + key.to_s) && !ENV['FIGARO_OVERRIDE'] == 'true'
     end
 
     def non_string_configuration!(value)


### PR DESCRIPTION
If ENV['FIGARO_OVERRIDE"] is set to "true", then never skip any variables.  This let's the application.yml always take precedence.
issue #148 
