### PR TITLE
Add support for --remote when pushing configs to Heroku

### DIFF
--- a/lib/figaro/cli.rb
+++ b/lib/figaro/cli.rb
@@ -30,6 +30,8 @@ module Figaro
       aliases: ["-p"],
       default: "config/application.yml",
       desc: "Specify a configuration file path"
+    method_option "remote",
+      desc: "Specify a Heroku git remote"
 
     define_method "heroku:set" do
       require "figaro/cli/heroku_set"

--- a/lib/figaro/cli/heroku_set.rb
+++ b/lib/figaro/cli/heroku_set.rb
@@ -10,11 +10,15 @@ module Figaro
       private
 
       def command
-        "heroku config:set #{vars} #{for_app}"
+        "heroku config:set #{vars} #{for_app} #{for_remote}"
       end
 
       def for_app
         options[:app] ? "--app=#{options[:app]}" : nil
+      end
+
+      def for_remote
+        options[:remote] ? "--remote=#{options[:remote]}" : nil
       end
 
       def vars

--- a/spec/figaro/cli/heroku_set_spec.rb
+++ b/spec/figaro/cli/heroku_set_spec.rb
@@ -46,6 +46,15 @@ EOF
     expect(command.args).to match_array(["foo=bar", "--app=foo-bar-app"])
   end
 
+  it "targets a specific Heroku git remote" do
+    run_simple("figaro heroku:set --remote production")
+
+    command = commands.last
+    expect(command.name).to eq("heroku")
+    expect(command.args.shift).to eq("config:set")
+    expect(command.args).to match_array(["foo=bar", "--remote=production"])
+  end
+
   it "handles values with special characters" do
     overwrite_file("config/application.yml", "foo: bar baz")
 


### PR DESCRIPTION
Heroku also supports a `--remote` flag, which targets the specified git remote.  This pull request provides support for that flag