### PR TITLE
Custom file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ Pusher.key    = Figaro.env.pusher_key!
 Pusher.secret = Figaro.env.pusher_secret!
 ```
 
+### Custom file location
+
+Say your deployment process require you to have your configuration at a certain file path or that you want to provide defaults for different platforms in development.
+You can achieve this by using an environment variable to tell Figaro where to look for your yaml file.
+
+```bash
+$ docker run -e FIGARO_FILE_PATH=./config/application.docker.yml my-container rails s
+```
+
+```bash
+$ FIGARO_FILE_PATH=/storage_device/configuration/my_app_variables.yml rails s
+```
+
+If you're not using rails or if you want to determine the file path by other means, set the `Figaro.adapter.path` to your desired value.
+
+```ruby
+require "figaro"
+Figaro.adapter.path = "/my/config/file.yml"
+Figaro.load
+```
+
 ### Deployment
 
 Figaro is written with deployment in mind. In fact, [Heroku](https://www.heroku.com)'s use of `ENV` for application configuration was the original inspiration for Figaro.

--- a/lib/figaro/rails/application.rb
+++ b/lib/figaro/rails/application.rb
@@ -6,7 +6,11 @@ module Figaro
       def default_path
         rails_not_initialized! unless ::Rails.root
 
-        ::Rails.root.join("config", "application.yml")
+        if ::ENV["FIGARO_FILE_PATH"]
+          ::Rails.root.join(::ENV["FIGARO_FILE_PATH"])
+        else
+          ::Rails.root.join("config", "application.yml")
+        end
       end
 
       def default_environment

--- a/spec/figaro/rails/application_spec.rb
+++ b/spec/figaro/rails/application_spec.rb
@@ -4,14 +4,32 @@ module Figaro
       describe "#default_path" do
         let!(:application) { Application.new }
 
-        it "defaults to config/application.yml in Rails.root" do
-          allow(::Rails).to receive(:root) { Pathname.new("/path/to/app") }
+        before { allow(::Rails).to receive(:root) { Pathname.new("/path/to/app") } }
 
+        it "defaults to config/application.yml in Rails.root" do
           expect {
             allow(::Rails).to receive(:root) { Pathname.new("/app") }
           }.to change {
             application.send(:default_path).to_s
           }.from("/path/to/app/config/application.yml").to("/app/config/application.yml")
+        end
+
+        it "defaults to path relative to Rails.root from the FIGARO_FILE_PATH environment variable" do
+          expect {
+            ::ENV["FIGARO_FILE_PATH"] = "./config/application.docker.yml"
+          }.to change {
+            application.send(:default_path).to_s
+          }.from("/path/to/app/config/application.yml").to("/path/to/app/config/application.docker.yml")
+          ::ENV["FIGARO_FILE_PATH"] = nil
+        end
+
+        it "defaults to absolute path from the FIGARO_FILE_PATH environment variable" do
+          expect {
+            ::ENV["FIGARO_FILE_PATH"] = "/var/config/my-app.yml"
+          }.to change {
+            application.send(:default_path).to_s
+          }.from("/path/to/app/config/application.yml").to("/var/config/my-app.yml")
+          ::ENV["FIGARO_FILE_PATH"] = nil
         end
 
         it "raises an error when Rails.root isn't set yet" do


### PR DESCRIPTION
Say your deployment process require you to have your configuration at a certain file path or that you want to provide defaults for different platforms in development.
You can achieve this by using an environment variable to tell Figaro where to look for your yaml file.

```bash
$ docker run -e FIGARO_FILE_PATH=./config/application.docker.yml my-container rails s
```

```bash
$ FIGARO_FILE_PATH=/storage_device/configuration/my_app_variables.yml rails s
```

If you're not using rails or if you want to determine the file path by other means, set the `Figaro.adapter.path` to your desired value.

```ruby
require "figaro"
Figaro.adapter.path = "/my/config/file.yml"
Figaro.load
```

---

Now you can get your environment variables using environment variables

![Infinity](http://mylittlefacewhen.com/media/f/img/mlfw1293_sweetie_belle_derelle_manecast.gif)
![Yo dawg](http://s3.amazonaws.com/rapgenius/yo-dawg-xzibit-48.jpg)