### PR TITLE
allow empty environment configuration

### DIFF
--- a/lib/figaro/application.rb
+++ b/lib/figaro/application.rb
@@ -29,7 +29,7 @@ module Figaro
     end
 
     def configuration
-      global_configuration.merge(environment_configuration)
+      global_configuration.merge(environment_configuration || {})
     end
 
     def load

--- a/lib/figaro/application.rb
+++ b/lib/figaro/application.rb
@@ -29,7 +29,7 @@ module Figaro
     end
 
     def configuration
-      global_configuration.merge(environment_configuration || {})
+      global_configuration.merge(environment_configuration)
     end
 
     def load
@@ -65,7 +65,7 @@ module Figaro
     end
 
     def environment_configuration
-      raw_configuration.fetch(environment) { {} }
+      raw_configuration.fetch(environment) { {} } || {}
     end
 
     def set(key, value)

--- a/spec/figaro/application_spec.rb
+++ b/spec/figaro/application_spec.rb
@@ -155,6 +155,17 @@ YAML
         expect(application.configuration).to eq("foo" => "BAR")
       end
 
+      it "handles an empty environment block" do
+        application = Application.new(path: yaml_to_path(<<-YAML))
+test:
+YAML
+        allow(application).to receive(:default_environment) { "test" }
+        expect {
+          application.configuration
+        }.to_not raise_error
+        expect(application.configuration).to eq({"test" => nil})
+      end
+
       it "follows a changing default path" do
         path_1 = yaml_to_path("foo: bar")
         path_2 = yaml_to_path("foo: baz")


### PR DESCRIPTION
I had an empty block in my config/application.yml and figaro crashed:
```
/home/sguth/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/figaro-1.1.0/lib/figaro/application.rb:34:in `merge': no implicit conversion of nil into Hash (TypeError)
        from /home/sguth/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/figaro-1.1.0/lib/figaro/application.rb:34:in `configuration'
```

This is a small patch to let it continue.

![Cat](http://i.imgur.com/LWMA0TL.gif)