### PR TITLE
Support the -r alias for Heroku remotes

### DIFF
--- a/lib/figaro/cli.rb
+++ b/lib/figaro/cli.rb
@@ -31,6 +31,7 @@ module Figaro
       default: "config/application.yml",
       desc: "Specify a configuration file path"
     method_option "remote",
+      aliases: ["-r"],
       desc: "Specify a Heroku git remote"
 
     define_method "heroku:set" do

--- a/spec/figaro/cli/heroku_set_spec.rb
+++ b/spec/figaro/cli/heroku_set_spec.rb
@@ -47,7 +47,7 @@ EOF
   end
 
   it "targets a specific Heroku git remote" do
-    run_simple("figaro heroku:set --remote production")
+    run_simple("figaro heroku:set -r production")
 
     command = commands.last
     expect(command.name).to eq("heroku")


### PR DESCRIPTION
This pull-request expands on the previously implemented support for git remotes, simply by adding the common alias: -r

I've modified the test to use the alias, which seems to be in the same style as the other tests for options that have aliases (-a and -e).