### PR TITLE
Don't "require 'rails'" at require-time #205

### DIFF
--- a/lib/figaro/rails.rb
+++ b/lib/figaro/rails.rb
@@ -1,9 +1,7 @@
-begin
-  require "rails"
-rescue LoadError
-else
+# at require-time, we need Rails to be defined to initialize the railtie
+# and set the default adapter to the Rails::Application adapter
+if defined?(Rails)
   require "figaro/rails/application"
   require "figaro/rails/railtie"
-
   Figaro.adapter = Figaro::Rails::Application
 end

--- a/spec/figaro/rails/application_spec.rb
+++ b/spec/figaro/rails/application_spec.rb
@@ -1,6 +1,12 @@
+require 'figaro/rails/application'
+
 module Figaro
   module Rails
     describe Application do
+      before do
+        stub_const('Rails', double('Rails'))
+      end
+
       describe "#default_path" do
         let!(:application) { Application.new }
 

--- a/spec/figaro_spec.rb
+++ b/spec/figaro_spec.rb
@@ -1,4 +1,11 @@
 describe Figaro do
+  describe 'require' do
+    it 'does not load Rails' do
+      require 'figaro'
+      expect(defined?(Rails)).to be nil
+    end
+  end
+
   describe ".env" do
     it "falls through to Figaro::ENV" do
       expect(Figaro.env).to eq(Figaro::ENV)


### PR DESCRIPTION
This addresses issue #205 and stops figaro from explicitly requiring rails.

![Here we go again](http://31.media.tumblr.com/3507d4544feba01ef8182146c400f42b/tumblr_inline_nqbmah1D6g1raprkq_500.gif)