### PR TITLE
Add require_keys_from_file functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Figaro.require_keys("pusher_app_id", "pusher_key", "pusher_secret")
 
 If any of the configuration keys above are not set, your application will raise an error during initialization. This method is preferred because it prevents runtime errors in a production application due to improper configuration.
 
+You can also require keys from a `*.yml` file. This is especially advantageous if you're using an application setup where `config/application.yml` is indexed in `.gitignore`. The following will prevent the application from starting if some environment variables are missing (e.g. on Heroku):
+
+```ruby
+# config/initializers/figaro.rb
+
+Figaro.require_keys_from_file("config/application.example.yml", Rails.env)
+```
+
 To require configuration keys lazily, reference the variables via "bang" methods on `Figaro.env`:
 
 ```ruby

--- a/lib/figaro.rb
+++ b/lib/figaro.rb
@@ -27,6 +27,11 @@ module Figaro
     missing_keys = keys.flatten - ::ENV.keys
     raise MissingKeys.new(missing_keys) if missing_keys.any?
   end
+
+  def require_keys_from_file(path, environment)
+    target_application = adapter.new(path: path, environment: environment)
+    require_keys(target_application.configuration.keys)
+  end
 end
 
 require "figaro/rails"


### PR DESCRIPTION
This commit adds support for requiring all keys present in a specified YAML file.

> This is especially advantageous if you're using an application setup where `config/application.yml` is indexed in `.gitignore`. The following will prevent the application from starting if some environment variables are missing (e.g. on Heroku).
> 
> ``` ruby
> Figaro.require_keys_from_file("config/application.example.yml", Rails.env)
> ```

I'm using this feature since a while and I already found some ENVs which my apps were missing only on Heroku.

