### PR TITLE
Add OpenShift integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,29 @@ For more information:
 $ figaro help heroku:set
 ```
 
+#### OpenShift
+
+for OpenShift you'd set env variables like:
+
+```bash
+$ rhc env-set google_analytics_key=UA-35722661-5
+```
+
+Using `figaro` you can set all values from your configuration similar to heroku:
+
+```bash
+$ figaro rhc:set
+```
+
+For all commandline options:
+
+```bash
+$ figaro help rhc:set
+```
+
 #### Other Hosts
 
-If you're not deploying to Heroku, you have two options:
+If you're not deploying to Heroku or OpenShift, you have two options:
 
 * Generate a remote configuration file
 * Set `ENV` variables directly

--- a/lib/figaro/cli.rb
+++ b/lib/figaro/cli.rb
@@ -38,5 +38,28 @@ module Figaro
       require "figaro/cli/heroku_set"
       HerokuSet.run(options)
     end
+
+    # figaro rhc:set
+
+    desc "rhc:set", "Send Figaro configuration to OpenShift"
+
+    method_option "app",
+      aliases: ["-a"],
+      desc: "Specify an OpenShift app"
+    method_option "namespace",
+      aliases: ["-n"],
+      desc: "Specify an OpenShift namespace"
+    method_option "environment",
+      aliases: ["-e"],
+      desc: "Specify an application environment"
+    method_option "path",
+      aliases: ["-p"],
+      default: "config/application.yml",
+      desc: "Specify a configuration file path"
+
+    define_method "rhc:set" do
+      require "figaro/cli/rhc_set"
+      RhcSet.run(options)
+    end
   end
 end

--- a/lib/figaro/cli/rhc_set.rb
+++ b/lib/figaro/cli/rhc_set.rb
@@ -1,0 +1,34 @@
+require 'figaro/cli/task'
+
+module Figaro
+  class CLI < Thor
+    # Send Figaro configuration to OpenShift
+    class RhcSet < Task
+      def run
+        system(configuration, command)
+      end
+
+      private
+
+      def command
+        "rhc env-set #{vars} #{for_app} #{for_namespace}"
+      end
+
+      def for_app
+        options[:app] ? "--app #{options[:app]}" : nil
+      end
+
+      def for_namespace
+        options[:namespace] ? "--namespace #{options[:namespace]}" : nil
+      end
+
+      def vars
+        configuration.keys.map { |k| var(k) }.join(' ')
+      end
+
+      def var(key)
+        Gem.win_platform? ? %(#{key}="%#{key}%") : %(#{key}="$#{key}")
+      end
+    end
+  end
+end

--- a/spec/figaro/cli/rhc_set_spec.rb
+++ b/spec/figaro/cli/rhc_set_spec.rb
@@ -1,0 +1,68 @@
+describe 'figaro rhc:set' do
+  before do
+    create_dir('example')
+    cd('example')
+    write_file('config/application.yml', 'foo: bar')
+  end
+
+  it 'sends Figaro configuration to OpenShift' do
+    run_simple('figaro rhc:set')
+
+    command = commands.last
+    expect(command.name).to eq('rhc')
+    expect(command.args).to eq(['env-set', 'foo=bar'])
+  end
+
+  it 'respects path' do
+    write_file('env.yml', 'foo: bar')
+
+    run_simple('figaro rhc:set -p env.yml')
+
+    command = commands.last
+    expect(command.name).to eq('rhc')
+    expect(command.args).to eq(['env-set', 'foo=bar'])
+  end
+
+  it 'respects environment' do
+    overwrite_file('config/application.yml', <<-EOF)
+foo: bar
+test:
+  foo: baz
+EOF
+
+    run_simple('figaro rhc:set -e test')
+
+    command = commands.last
+    expect(command.name).to eq('rhc')
+    expect(command.args).to eq(['env-set', 'foo=baz'])
+  end
+
+  it 'targets a specific OpenShift app' do
+    run_simple('figaro rhc:set -a foo-bar-app')
+
+    command = commands.last
+    expect(command.name).to eq('rhc')
+    expect(command.args.shift).to eq('env-set')
+    expect(command.args).to match_array(['foo=bar', '--app', 'foo-bar-app'])
+  end
+
+  it 'targets a specific OpenShift namespace' do
+    run_simple('figaro rhc:set -a fooapp -n teambar')
+
+    command = commands.last
+    expect(command.name).to eq('rhc')
+    expect(command.args.shift).to eq('env-set')
+    expect(command.args).to match_array(['foo=bar', '--app',
+                                         'fooapp', '--namespace', 'teambar'])
+  end
+
+  it 'handles values with special characters' do
+    overwrite_file('config/application.yml', 'foo: bar baz')
+
+    run_simple('figaro rhc:set')
+
+    command = commands.last
+    expect(command.name).to eq('rhc')
+    expect(command.args).to eq(['env-set', 'foo=bar baz'])
+  end
+end

--- a/spec/support/bin/rhc
+++ b/spec/support/bin/rhc
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('../../command_interceptor', __FILE__)
+
+CommandInterceptor.intercept('rhc')


### PR DESCRIPTION
Create command and spec for `figaro rhc:set`
which sends configuration to OpenShift via `rhc`
*similarly to the* `figaro heroku:set` *command*

@laserlemon not sure if this is outside of the scope of the project, let me know if it is.