### PR TITLE
Migrate to new code standard

### DIFF
--- a/lib/figaro/cli/install.rb
+++ b/lib/figaro/cli/install.rb
@@ -19,7 +19,7 @@ module Figaro
       end
 
       def ignore_configuration
-        if File.exists?(".gitignore")
+        if File.exist?(".gitignore")
           append_to_file(".gitignore", <<-EOF)
 
 # Ignore application configuration


### PR DESCRIPTION
`File.exists?` is deprecated in favor of `File.exist?`