### PR TITLE
Use constant time lookups in Figaro::ENV#get_value method

### DIFF
--- a/lib/figaro/env.rb
+++ b/lib/figaro/env.rb
@@ -38,8 +38,7 @@ module Figaro
     end
 
     def get_value(key)
-      _, value = ::ENV.detect { |k, _| k.downcase == key }
-      value
+      ::ENV[key] || ::ENV[key.upcase]
     end
   end
 end


### PR DESCRIPTION
Please refer Issue https://github.com/laserlemon/figaro/issues/236

This PR tries to change the Figaro::ENV#get_value method with constant time lookups on `ENV` variables.

This update improves the performance especially when the size of `ENV` variable is large.