### PR TITLE
adds cli subcommand for dumping configs in application.yml to STDOUT

### DIFF
--- a/lib/figaro/cli.rb
+++ b/lib/figaro/cli.rb
@@ -16,6 +16,26 @@ module Figaro
       Install.start
     end
 
+    # figaro configs:dump
+
+    desc "configs:dump", "Dump configs to STDOUT in an exportable format"
+    method_option "app_name",
+      aliases: ["-a"],
+      desc: "Specify a Dokku app name"
+    method_option "dokku_alias",
+      aliases: ["-z"],
+      desc: "Specify an alias you use to run the dokku/ paas command"
+    method_option "path",
+      aliases: ["-p"],
+      default: "config/application.yml",
+      desc: "Specify a configuration file path"
+
+    define_method "configs:dump" do
+      require "figaro/cli/configs_dump"
+      ConfigsDump.run(options)
+    end
+
+
     # figaro heroku:set
 
     desc "heroku:set", "Send Figaro configuration to Heroku"

--- a/lib/figaro/cli/configs_dump.rb
+++ b/lib/figaro/cli/configs_dump.rb
@@ -1,0 +1,37 @@
+require "figaro/cli/task"
+
+module Figaro
+  class CLI < Thor
+    class ConfigsDump < Task
+      def run
+        puts command
+      end
+
+      private
+
+      def command
+        # system(configuration, "printf \"#{app_name} #{vars}\"")
+        # "printf \"config:set save_kittens #{vars} #{for_app} #{for_remote}\n\""
+
+        env_vars = configuration.map { |k,v| "#{k.to_s}=\"#{v.to_s.gsub(" ", "\\ ")}\"" unless v.nil? }.join(" ")
+        "#{dokku_alias} #{app_name} #{env_vars}"
+      end
+
+      def app_name
+        options[:app_name] ? "config:set #{options[:app_name]}" : nil
+      end
+
+      def dokku_alias
+        options[:dokku_alias] ? "#{options[:dokku_alias]}" : nil
+      end
+
+      def vars
+        configuration.keys.map { |k| var(k) }.join(" ")
+      end
+
+      def var(key)
+        Gem.win_platform? ? %(#{key}="%#{key}%") : %(#{key}="$#{key}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here's a feature for just dumping `application.yml` data into a format that one can easily do say `export DUMP_RESULTS` or place into a `setup_env.sh` file.  

What do you think?  (relates to #222)

Update:  
Oh sorry for leaving such a hasty PR, I'm in the middle of a bunch of devops stuff on a tight time schedule.  I wrote this feature out to work as a stand alone listing of ENV vars like `A="a" B="b"` but you can also add switches to make it easy to set configs on heroku-like platforms `dokku config:set APP_NAME A="a" B="b"`
