### PR TITLE
Add scalingo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,26 @@ For more information:
 $ figaro help heroku:set
 ```
 
+#### Scalingo
+
+The scalingo cli makes setting application environment variable easy:
+
+```bash
+$ scalingo env-set stripe_api_key=foobarabcdef123456789
+```
+
+Using the `figaro` command, you can set values from your configuration file all at once:
+
+```bash
+$ figaro scalingo:set -e production
+```
+
+For more information:
+
+```bash
+$ figaro help scalingo:set
+```
+
 #### Other Hosts
 
 If you're not deploying to Heroku, you have two options:

--- a/lib/figaro/cli.rb
+++ b/lib/figaro/cli.rb
@@ -38,5 +38,28 @@ module Figaro
       require "figaro/cli/heroku_set"
       HerokuSet.run(options)
     end
+
+    # figaro scalingo:set
+
+    desc "scalingo:set", "Send Figaro configuration to scalingo"
+
+    method_option "app",
+      aliases: ["-a"],
+      desc: "Specify a Scalingo app"
+    method_option "environment",
+      aliases: ["-e"],
+      desc: "Specify an application environment"
+    method_option "path",
+      aliases: ["-p"],
+      default: "config/application.yml",
+      desc: "Specify a configuration file path"
+    method_option "remote",
+      aliases: ["-r"],
+      desc: "Specify a Scalingo git remote"
+
+    define_method "scalingo:set" do
+      require "figaro/cli/scalingo_set"
+      ScalingoSet.run(options)
+    end
   end
 end

--- a/lib/figaro/cli/scalingo_set.rb
+++ b/lib/figaro/cli/scalingo_set.rb
@@ -1,0 +1,33 @@
+require "figaro/cli/task"
+
+module Figaro
+  class CLI < Thor
+    class ScalingoSet < Task
+      def run
+        system(configuration, command)
+      end
+
+      private
+
+      def command
+        "scalingo #{for_app} #{for_remote} env-set #{vars}"
+      end
+
+      def for_app
+        options[:app] ? "--app #{options[:app]}" : nil
+      end
+
+      def for_remote
+        options[:remote] ? "--remote #{options[:remote]}" : nil
+      end
+
+      def vars
+        configuration.keys.map { |k| var(k) }.join(" ")
+      end
+
+      def var(key)
+        Gem.win_platform? ? %(#{key}="%#{key}%") : %(#{key}="$#{key}")
+      end
+    end
+  end
+end

--- a/spec/figaro/cli/scalingo_set_spec.rb
+++ b/spec/figaro/cli/scalingo_set_spec.rb
@@ -1,0 +1,65 @@
+describe "figaro scalingo:set" do
+  before do
+    create_dir("example")
+    cd("example")
+    write_file("config/application.yml", "foo: bar")
+  end
+
+  it "sends Figaro configuration to Scalingo" do
+    run_simple("figaro scalingo:set")
+
+    command = commands.last
+    expect(command.name).to eq("scalingo")
+    expect(command.args).to eq(["env-set", "foo=bar"])
+  end
+
+  it "respects path" do
+    write_file("env.yml", "foo: bar")
+
+    run_simple("figaro scalingo:set -p env.yml")
+
+    command = commands.last
+    expect(command.name).to eq("scalingo")
+    expect(command.args).to eq(["env-set", "foo=bar"])
+  end
+
+  it "respects environment" do
+    overwrite_file("config/application.yml", <<-EOF)
+foo: bar
+test:
+  foo: baz
+EOF
+
+    run_simple("figaro scalingo:set -e test")
+
+    command = commands.last
+    expect(command.name).to eq("scalingo")
+    expect(command.args).to eq(["env-set", "foo=baz"])
+  end
+
+  it "targets a specific Scalingo app" do
+    run_simple("figaro scalingo:set -a foo-bar-app")
+
+    command = commands.last
+    expect(command.name).to eq("scalingo")
+    expect(command.args).to match_array(["--app", "foo-bar-app", "env-set", "foo=bar"])
+  end
+
+  it "targets a specific Scalingo git remote" do
+    run_simple("figaro scalingo:set -r production")
+
+    command = commands.last
+    expect(command.name).to eq("scalingo")
+    expect(command.args).to match_array(["--remote", "production", "env-set", "foo=bar"])
+  end
+
+  it "handles values with special characters" do
+    overwrite_file("config/application.yml", "foo: bar baz")
+
+    run_simple("figaro scalingo:set")
+
+    command = commands.last
+    expect(command.name).to eq("scalingo")
+    expect(command.args).to eq(["env-set", "foo=bar baz"])
+  end
+end

--- a/spec/support/bin/scalingo
+++ b/spec/support/bin/scalingo
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../command_interceptor", __FILE__)
+
+CommandInterceptor.intercept("scalingo")


### PR DESCRIPTION
Add support for the Scalingo PAAS. (https://scalingo.com/)

This PR add the `figaro scalingo:set` command.
With the following flags:
- -a to specify a custom application
- -r to specify a git remote

This also add rspec tests for the scalingo:set command (based on heroku tests).
