### PR TITLE
Ensure that Figaro.adapter is set to Figaro::Rails::Application before the figaro Railtie is loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /gemfiles/*.gemfile.lock
 /pkg
 /tmp
+**/*.sqllite
+**/log/*.log

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test do
   gem "codeclimate-test-reporter", require: false
   gem "rspec", "~> 3.1"
   gem "sqlite3", "~> 1.3"
+  gem "combustion"
 end

--- a/lib/figaro/rails.rb
+++ b/lib/figaro/rails.rb
@@ -3,7 +3,6 @@ begin
 rescue LoadError
 else
   require "figaro/rails/application"
-  require "figaro/rails/railtie"
-
   Figaro.adapter = Figaro::Rails::Application
+  require "figaro/rails/railtie"
 end

--- a/spec/figaro_spec.rb
+++ b/spec/figaro_spec.rb
@@ -58,6 +58,12 @@ describe Figaro do
     end
   end
 
+  describe "railtie configuration" do
+    it "loads railtie after the adapter is set to Figaro::Rails::Application" do
+      expect(ENV['ENGINE_VALUE']).to eq('diesel')
+    end
+  end
+
   describe ".require_keys" do
     before do
       ::ENV["foo"] = "bar"

--- a/spec/internal/config/application.yml
+++ b/spec/internal/config/application.yml
@@ -1,0 +1,1 @@
+ENGINE_VALUE: diesel

--- a/spec/internal/config/initializers/initialize_figaro.rb
+++ b/spec/internal/config/initializers/initialize_figaro.rb
@@ -1,0 +1,7 @@
+require 'figaro'
+
+Figaro.application = Figaro::Application.new(
+  environment: ::Rails.env,
+  path: File.expand_path('../application.yml', __dir__)
+)
+Figaro.load

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,10 @@ if ENV["CODECLIMATE_REPO_TOKEN"]
   CodeClimate::TestReporter.start
 end
 
+# This block of code helps to test the Railtie initialisation order. It cannot go directly in a spec
+# as it is about how gems are required.
 require 'rails'
 require 'combustion'
-
 Combustion.initialize!
 
 require "figaro"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,11 @@ if ENV["CODECLIMATE_REPO_TOKEN"]
   CodeClimate::TestReporter.start
 end
 
+require 'rails'
+require 'combustion'
+
+Combustion.initialize!
+
 require "figaro"
 
 Bundler.require(:test)


### PR DESCRIPTION
Figaro should be able to be used in the initializer of a Rails engine. Unfortunately, when testing the engine using a tool like [Combustion](https://github.com/pat/combustion), we see that the Railtie to load figaro is added immediately after the definition of `Figaro::Rails::Application`. 

This can (and sometimes does) mean that the `before_configuration` block of that Railtie is immediately executed. At this point, the `Figaro.adapter` is still `nil`, so it is lazily created as a `Figaro::Application`. The Railtie then calls `Figaro.load` on it, and it blows up as `default_path` throws a `NotImplementedError`.

The solution is to set the adapter to a `Figaro::Rails::Application` as soon as possible, and before the Railtie is created.

This PR makes that 2 line swap change, and adds Combustion to the specs. If the two lines of logic are not swapped, you can see how the initializing process fails.