### PR TITLE
.gitignore file does not repeat itself

### DIFF
--- a/lib/figaro/cli/install.rb
+++ b/lib/figaro/cli/install.rb
@@ -18,8 +18,9 @@ module Figaro
         copy_file("application.yml", options[:path])
       end
 
+
       def ignore_configuration
-        if File.exists?(".gitignore")
+        if File.exists?(".gitignore") && is_not_ignored?
           append_to_file(".gitignore", <<-EOF)
 
 # Ignore application configuration
@@ -27,6 +28,11 @@ module Figaro
 EOF
         end
       end
+
+      private
+        def is_not_ignored?
+          !File.readlines(".gitignore").any?{ |l| l["/#{options[:path]}"] }
+        end
     end
   end
 end

--- a/spec/figaro/cli/install_spec.rb
+++ b/spec/figaro/cli/install_spec.rb
@@ -46,4 +46,20 @@ EOF
       check_file_presence([".gitignore"], false)
     end
   end
+
+  context "with a .gitignore file already ingnoring path" do
+    before do
+      write_file(".gitignore", <<-EOF)
+/foo
+/bar
+/config/application.yml
+EOF
+    end
+    it "doesn't repeat itself in .gitignore file" do
+      run_simple("figaro install")
+
+      check_file_content(".gitignore", %r(^/config/application\.yml$), true)
+      check_file_content(".gitignore", %r(^# Ignore application configuration$), false)
+    end
+  end
 end


### PR DESCRIPTION
The .gitignore file will not be appened to if "/#{options[:path]}" is already present.

Some people may delete the comment "# Ignore application configuration" from .gitignore. Then running `bundle exec figaro install` would previously append both lines:
```
# Ignore application configuration
/#{options[:path]}
```
Now it will check to see if "/#{options[:path]}" is already present and only append if it is not.

GIF:
http://giphy.com/gifs/fight-club-work-edward-norton-YAy9NNu16pYYg