### PR TITLE
Remove escape characters when loading environment values #280

### DIFF
--- a/lib/figaro/env.rb
+++ b/lib/figaro/env.rb
@@ -39,7 +39,7 @@ module Figaro
 
     def get_value(key)
       _, value = ::ENV.detect { |k, _| k.downcase == key }
-      value
+      eval("\"#{value}\"") if value
     end
   end
 end

--- a/spec/figaro/env_spec.rb
+++ b/spec/figaro/env_spec.rb
@@ -31,6 +31,11 @@ describe Figaro::ENV do
         allow(env).to receive(:bar) { "baz" }
         expect(env.bar).to eq("baz")
       end
+
+      it "removes escape characters" do
+        ::ENV["bar"] = 'baz\$baz'
+        expect(env.bar).to eq("baz$baz")
+      end
     end
 
     context "bang methods" do


### PR DESCRIPTION
Let's say you have `app_key: e$Gu768HKkiec` in your application.yml. When calling `Figaro.env.app_key` Figaro will display the value as `e\$Gu768HKkiec` which does not match what is the config file because of `\` escape character. Figaro needs to be improved to remove the escape characters.