### PR TITLE
Removing thor version requirement allows rails 6 to bundle

### DIFF
--- a/figaro.gemspec
+++ b/figaro.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage    = "https://github.com/laserlemon/figaro"
   gem.license     = "MIT"
 
-  gem.add_dependency "thor", "~> 0.14"
+  gem.add_dependency "thor"
 
   gem.add_development_dependency "bundler", "~> 1.7"
   gem.add_development_dependency "rake", "~> 10.4"


### PR DESCRIPTION
Quick hack. Probably not the best fix but it allows rails 6 to bundle and seems to be working properly now