### PR TITLE
Support Psych v4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,7 @@ rvm:
   - "2.5"
   - "2.6"
   - "2.7"
+  - "3.0"
+  - "3.1"
   - ruby-head
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rails", ">= 5.2.0", "< 6.1"
+gem "rails", ">= 5.2.0", "< 7.1"
 
 group :test do
   gem "aruba", "~> 1.0"

--- a/lib/figaro/application.rb
+++ b/lib/figaro/application.rb
@@ -57,7 +57,10 @@ module Figaro
     end
 
     def parse(path)
-      File.exist?(path) && YAML.load(ERB.new(File.read(path)).result) || {}
+      return {} unless File.exist?(path)
+
+      payload = ERB.new(File.read(path)).result
+      (YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)) || {}
     end
 
     def global_configuration

--- a/spec/figaro/application_spec.rb
+++ b/spec/figaro/application_spec.rb
@@ -105,6 +105,17 @@ YAML
         expect(application.configuration).to eq("foo" => "bar")
       end
 
+      it "loads alias from YAML" do
+        application = Application.new(path: yaml_to_path(<<-YAML), environment: "development")
+default: &defaults
+  foo: bar
+development:
+  <<: *defaults
+YAML
+
+        expect(application.configuration).to eq("foo" => "bar")
+      end
+
       it "merges environment-specific values" do
         application = Application.new(path: yaml_to_path(<<-YAML), environment: "test")
 foo: bar

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -1,11 +1,18 @@
 describe Figaro::Rails do
   before do
+    spec = Bundler.locked_gems.specs.find { |spec| spec.name == 'rails' }
+    skip_asset_pipeline_option = if spec.version >= '7.0.0'
+                                   '--skip_asset_pipeline'
+                                 else
+                                   '--skip-sprockets'
+                                 end
+
     run_command_and_stop(<<-CMD)
       rails new example \
         --skip-gemfile \
         --skip-git \
         --skip-keeps \
-        --skip-sprockets \
+        #{skip_asset_pipeline_option} \
         --skip-spring \
         --skip-listen \
         --skip-javascript \


### PR DESCRIPTION
Ruby master ships with Psych 4.0.0 which makes YAML.load
defaults to safe mode (https://github.com/ruby/psych/pull/487).

Keep compatibility by using unsafe_load.

---

- Add 3.0 and 3.1 to .travis.yml
- Loose version lock of Rails to 7.0.0
- Keep compatibility by using YAML.unsafe_load