### PR TITLE
Change exist method for gitignore

### DIFF
--- a/lib/figaro/cli/install.rb
+++ b/lib/figaro/cli/install.rb
@@ -19,7 +19,7 @@ module Figaro
       end
 
       def ignore_configuration
-        if File.exists?(".gitignore")
+        if File.exist?(".gitignore")
           append_to_file(".gitignore", <<-EOF)
 
 # Ignore application configuration


### PR DESCRIPTION
- In method ignore_configuration exists? the method was coursing issue anytime I execute Figaro gem 