### PR TITLE
Remove sample keys from configuration template

### DIFF
--- a/lib/figaro/cli/install/application.yml
+++ b/lib/figaro/cli/install/application.yml
@@ -1,11 +1,11 @@
 # Add configuration values here, as shown below.
 #
-# pusher_app_id: "2954"
-# pusher_key: 7381a978f7dd7f9a1117
-# pusher_secret: abdc3b896a0ffb85d373
-# stripe_api_key: sk_test_2J0l093xOyW72XUYJHE4Dv2r
-# stripe_publishable_key: pk_test_ro9jV5SNwGb1yYlQfzG17LHK
+# pusher_app_id: "%pusher-app-id-here%"
+# pusher_key: %pusher-api-key-here%
+# pusher_secret: %pusher-secret-key-here%
+# stripe_api_key: %stripe-api-key-here%
+# stripe_publishable_key: %stripe-publishable-key-here%
 #
 # production:
-#   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
-#   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
+#   stripe_api_key: %stripe-api-key-for-production-here%
+#   stripe_publishable_key: %stripe-publishable-key-for-production-here%


### PR DESCRIPTION
Removed the seemingly valid keys from the template, Vulnerability Scanners like [`trivy`](https://github.com/aquasecurity/trivy) will report this file as a false positive for credential leakage.

I admit, this is a rather silly change :sweat_smile: 
