### PR TITLE
Use YAML safe load with aliases with Psych gem version >= 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,20 @@ branches:
   only:
     - master
 gemfile:
-  - gemfiles/rails52.gemfile
-  - gemfiles/rails60.gemfile
-  - gemfiles/rails6.gemfile
+  - gemfiles/rails61.gemfile
+  - gemfiles/rails70.gemfile
+  - gemfiles/rails71.gemfile
 jobs:
   allow_failures:
-    - rvm: ruby-head
-    - gemfile: gemfiles/rails6.gemfile
+    - rvm: '3.3'
+      gemfile: gemfiles/rails61.gemfile
+    - rvm: '3.2'
+      gemfile: gemfiles/rails61.gemfile
+    
 language: ruby
 rvm:
-  - "2.5"
-  - "2.6"
-  - "2.7"
-  - ruby-head
+  - "3.0"
+  - "3.1"
+  - "3.2"
+  - "3.3"
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rails", ">= 5.2.0", "< 6.1"
+gem "rails", ">= 5.2.0", "< 7.2"
 
 group :test do
   gem "aruba", "~> 1.0"

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 6.1"
 
 group :test do
   gem "aruba", "~> 1.0"

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 6.0"
+gem "rails", "~> 7.0"
 
 group :test do
   gem "aruba", "~> 1.0"

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 7.1"
 
 group :test do
   gem "aruba", "~> 1.0"

--- a/lib/figaro/application.rb
+++ b/lib/figaro/application.rb
@@ -57,7 +57,16 @@ module Figaro
     end
 
     def parse(path)
-      File.exist?(path) && YAML.load(ERB.new(File.read(path)).result) || {}
+      return {} unless File.exist?(path)
+
+      payload = ERB.new(File.read(path)).result
+
+      result = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("4")
+        YAML.safe_load(payload, aliases: true)
+      else
+        YAML.load(payload)
+      end
+      result || {}
     end
 
     def global_configuration

--- a/lib/figaro/cli/install.rb
+++ b/lib/figaro/cli/install.rb
@@ -19,7 +19,7 @@ module Figaro
       end
 
       def ignore_configuration
-        if File.exists?(".gitignore")
+        if File.exist?(".gitignore")
           append_to_file(".gitignore", <<-EOF)
 
 # Ignore application configuration

--- a/spec/figaro/application_spec.rb
+++ b/spec/figaro/application_spec.rb
@@ -105,6 +105,17 @@ YAML
         expect(application.configuration).to eq("foo" => "bar")
       end
 
+      it "loads alias from YAML" do
+        application = Application.new(path: yaml_to_path(<<-YAML), environment: "development")
+default: &defaults
+  foo: bar
+development:
+  <<: *defaults
+YAML
+
+        expect(application.configuration).to eq("foo" => "bar")
+      end
+
       it "merges environment-specific values" do
         application = Application.new(path: yaml_to_path(<<-YAML), environment: "test")
 foo: bar

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -1,11 +1,19 @@
 describe Figaro::Rails do
   before do
+    rails_spec = Bundler.locked_gems.specs.find { |spec| spec.name == "rails" }
+    skip_asset_pipeline_option =
+      if rails_spec.version >= Gem::Version.new("7.0.0")
+        "--skip-asset-pipeline"
+      else
+        "--skip-sprockets"
+      end
+
     run_command_and_stop(<<-CMD)
       rails new example \
         --skip-gemfile \
         --skip-git \
         --skip-keeps \
-        --skip-sprockets \
+        #{skip_asset_pipeline_option} \
         --skip-spring \
         --skip-listen \
         --skip-javascript \


### PR DESCRIPTION
Remove old Ruby versions. Focus on Ruby 3.0, 3.1, 3.2 and 3.3.
Remove old Ruby on Rails versions. Focus on Ruby on Rails 6.1, 7.0 and 7.1.